### PR TITLE
Fix mobile zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Corporate Climb Clicker v2.0</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <style>
     body {
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;


### PR DESCRIPTION
## Summary
- disable mobile zoom by disallowing scaling in the viewport meta tag

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684b59d2a5308323b08046c6e2d73bce